### PR TITLE
Updated docker-compose Version Number and Configured to Use Container Host's Network Stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
-version: '2'
+version: '3.8'
 services:
   server:
     build:
       context: .
       dockerfile: Dockerfile
+      network: host
     image: result/latest
     ports:
       - "4000:4000"
     volumes:
       - ".:/src"
+    network_mode: "host"


### PR DESCRIPTION
Summary:
- Version number **changed to 3.8** from 2
- Modified to use container host's network stack by:
   - Adding `network` key with value of `host` under `build`
   - Adding `network_mode` key with value of `"host"` under `server`.

These changes ensure that the container uses the host's IP address and networking services to make external connections, which prevents firewalls from blocking the container's connections as long as the host is able to pass through the firewall.

Closes #11 